### PR TITLE
fix: resolve YAML syntax error in extension-changelog workflow

### DIFF
--- a/.github/workflows/extension-changelog.yml
+++ b/.github/workflows/extension-changelog.yml
@@ -79,11 +79,7 @@ jobs:
               owner,
               repo,
               issue_number: number,
-              body: `📝 **Changelog will be updated automatically** when this PR is merged to main.
-              
-The changelog entry will use this PR's title: "${context.payload.pull_request.title}"
-
-If you want to customize the changelog entry, please update the PR title before merging.`
+              body: `📝 **Changelog will be updated automatically** when this PR is merged to main.\n\nThe changelog entry will use this PR's title: "${context.payload.pull_request.title}"\n\nIf you want to customize the changelog entry, please update the PR title before merging.`
             });
           }
 


### PR DESCRIPTION
🔧 **Critical Workflow Fix**

This PR fixes a YAML syntax error that was preventing the changelog automation from working.

## Problem 🐛
- **Line 86**: Multi-line template literal in GitHub script was causing YAML parsing errors
- **Impact**: Changelog automation workflow couldn't run due to invalid YAML
- **Error**: `You have an error in your yaml syntax on line 86`

## Solution ✅
- ✅ **Fixed multi-line string** - converted to single line with explicit `\n` characters
- ✅ **Preserved formatting** - same message output, just proper YAML syntax
- ✅ **Validated syntax** - no more linting errors

## Before (Broken):
```yaml
body: `📝 **Changelog will be updated automatically** when this PR is merged to main.
              
The changelog entry will use this PR's title: "${context.payload.pull_request.title}"

If you want to customize the changelog entry, please update the PR title before merging.`
```

## After (Fixed):
```yaml
body: `📝 **Changelog will be updated automatically** when this PR is merged to main.\n\nThe changelog entry will use this PR's title: "${context.payload.pull_request.title}"\n\nIf you want to customize the changelog entry, please update the PR title before merging.`
```

## Impact 🚀
- 🔧 **Enables changelog automation** - workflow can now run without syntax errors
- 📝 **Unblocks testing** - PR comments and changelog updates will work
- ⚡ **Ready for merge** - critical fix for automation system

**Priority: HIGH** - This fix is required for the changelog automation to function.