### PR TITLE
fix: correct YAML syntax error in extension-changelog workflow

### DIFF
--- a/.github/workflows/extension-changelog.yml
+++ b/.github/workflows/extension-changelog.yml
@@ -221,11 +221,7 @@ jobs:
         
         # Commit changelog changes
         git add CHANGELOG.md
-        git commit -m "docs: update extension changelog for v${CURRENT_VERSION}
-
-Automatically generated changelog update after merge to main.
-
-[skip ci]"
+        git commit -m "docs: update extension changelog for v${CURRENT_VERSION} - Automatically generated changelog update after merge to main. [skip ci]"
         
         # Push branch
         git push origin "$BRANCH_NAME"


### PR DESCRIPTION
## 🛠️ Fix YAML Syntax Error

This PR fixes the YAML syntax error on line 226 of `.github/workflows/extension-changelog.yml` that was preventing the changelog automation from working.

### 🐛 Problem
- Multi-line commit message was not properly formatted in YAML
- Caused workflow validation error: "You have an error in your yaml syntax on line 226"

### ✅ Solution  
- Converted multi-line commit message to single line format
- Maintains the same commit message content but in YAML-compatible format

### 🔍 Changes
- Fixed commit message format in extension-changelog workflow
- No functional changes to the automation logic

This should allow the changelog automation to work properly for testing in PR #10.