### PR TITLE
fix: correct workflow job dependency error

### DIFF
--- a/.github/workflows/extension-changelog.yml
+++ b/.github/workflows/extension-changelog.yml
@@ -325,7 +325,7 @@ jobs:
   # Summary job
   changelog-summary:
     runs-on: ubuntu-latest
-    needs: [detect-extension-changes, update-changelog-in-pr, update-changelog-on-merge, generate-release-notes]
+    needs: [detect-extension-changes, check-changelog-in-pr, update-changelog-on-merge, generate-release-notes]
     if: always() && needs.detect-extension-changes.outputs.extension-files == 'true'
     steps:
     - name: Report changelog status


### PR DESCRIPTION
## 🐛 Fix Workflow Job Dependency Error

This PR fixes a critical workflow dependency error that was preventing the extension-changelog workflow from running.

### ❌ **Problem**
```
Invalid workflow file: .github/workflows/extension-changelog.yml#L328
Job 'changelog-summary' depends on unknown job 'update-changelog-in-pr'.
```

### ✅ **Solution**
Changed the job dependency in `changelog-summary` from:
- ❌ `update-changelog-in-pr` (incorrect/non-existent job name)
- ✅ `check-changelog-in-pr` (correct job name)

### 📋 **Workflow Jobs Verification**
The actual jobs in the workflow are:
1. `detect-extension-changes` ✅
2. `check-changelog-in-pr` ✅ 
3. `update-changelog-on-merge` ✅
4. `generate-release-notes` ✅
5. `changelog-summary` ✅

### 🔍 **Root Cause**
Simple typo/mismatch in the job name reference in the `needs` dependency array.

### 🎯 **Result**
- ✅ **Workflow is now valid** - No more dependency errors
- ✅ **All job dependencies correct** - Proper execution order maintained  
- ✅ **Ready for testing** - Changelog automation can now run

### 🚀 **Next Steps**
Once merged, the changelog automation should work correctly for testing with PRs that modify VSCode extension files.